### PR TITLE
feat!: Update schema marshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ package main
 type Address struct {
     Street string `prompt:"street,string,required" prompt_description:"Street name."`
     City   string `prompt:"city,string,required"`
+    Country string `prompt:"country,string" prompt_enum:"US,CA,MX,INVALID"`
 }
 
 type UserProfile struct {
     FullName    string  `prompt:"full_name,string,required" prompt_description:"User's full name."`
-    Age         int     `prompt:"age,integer"`
-    PrimaryAddr Address `prompt:"primary_address,object,required"`
+    Age         *int     `prompt:"age,integer"` // Pointer values set the schema to Nullable
+    DateOfBirth time.Time  `prompt:"dateOfBirth,string,date-time"`
+    Addresses []Address `prompt:"addresses,object,required"`
+    TemplatedDescription string `prompt:"templatedDescription,string" prompt_description:"This is a templated description with a variable: {example_detail}"`
 }
 ```
 
@@ -79,12 +82,23 @@ if err != nil {
 
 ## Struct Tag Reference
 
-- **`prompt:"<name>,<type>[,required]"`**:
+- **`prompt:"<name>,<type>[,format][,required]"`**:
   - `name`: JSON property name.
-  - `type`: `string`, `bool`, `number`, `integer`, `array`, `object`.
+  - `type`: `string`, `bool`, `number`, `integer`, `object`.
+    - For array/slice fields, specify the expected type of the array items e.g.
+    ```
+    Addresses []Address `prompt:"addresses,object`
+    Names []string `prompt:"names,string`
+    ```
+  - `format`: (Optional) Describe the expected format of the value to be returned as per [OpenApi 3.0 spec](https://spec.openapis.org/registry/format/#formats-registry) e.g. `date-time` (for ISO 8601)
+    - If `prompt_enum` is present, format `enum` is automatically set if not explicitly overridden.
+    - If type `number` is present, format `float` is automatically set if not explicitly overridden.
   - `required`: (Optional) Marks field as required.
+- **`prompt_enum:"<value1>,<value2>,..."`**: (Optional) Specify an enumeration of possible return values in a comma-separated list.
+  - Sets the format to `enum` if a format is not explicitly set.
 - **`prompt_description:"<text>"`**: (Optional) Field description. Supports `{var}` templating.
 - **`prompt_aliases:"<alias1>,<alias2>"`**: (Optional) Alternative names, added to description.
+- If field is a pointer, it's marked as Nullable
 
 ## Contributing
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -19,29 +19,52 @@ type Event struct {
 	Name string `json:"name" prompt:"name,string" prompt_description:"The name of the event"`
 }
 
+type Embedded struct {
+	EmbeddedField string `json:"embeddedField" prompt:"embeddedField,string,required"`
+}
+
 type TestPrompt struct {
-	Ignored      string          `json:"ignored"`
-	DocumentDate time.Time       `json:"documentDate" prompt:"documentDate,string,required"`
-	PublishDate  time.Time       `json:"publishDate" prompt:"publishDate,string" prompt_description:"The date the document was published"`
-	Title        string          `json:"title" prompt:"title,string" prompt_description:"The title of the document under the series {seriesName}"`
-	FirstName    string          `json:"firstName" prompt:"firstName,string" prompt_aliases:"givenName"`
-	LastName     string          `json:"lastName" prompt:"lastName,string" prompt_aliases:"surName,familyName"`
-	Witness      string          `json:"witness" prompt:"witness,string" prompt_description:"The person from {seriesName} who witnessed the document signing." prompt_aliases:"witnessName,witnessedBy"`
-	IsParsed     bool            `json:"isParsed" prompt:"isParsed,bool"`
-	Amount       decimal.Decimal `json:"amount" prompt:"totalAmount,number"`
-	Metadata     Metadata        `json:"metadata" prompt:"metadata,object"`
-	Tags         []string        `json:"tags" prompt:"tags,string"`
-	Events       []Event         `json:"events" prompt:"events,object"`
+	unexported     string
+	Ignored        string          `json:"ignored"`
+	DocumentDate   time.Time       `json:"documentDate" prompt:"documentDate,string,required"`
+	CreationDate   time.Time       `json:"creationDate" prompt:"creationDate,string,date-time,required"`
+	PublishDate    string          `json:"publishDate" prompt:"publishDate,string" prompt_description:"The date the document was published"`
+	Title          string          `json:"title" prompt:"title,string" prompt_description:"The title of the document under the series {seriesName}"`
+	FirstName      string          `json:"firstName" prompt:"firstName,string" prompt_aliases:"givenName"`
+	LastName       string          `json:"lastName" prompt:"lastName,string" prompt_aliases:"surName,familyName"`
+	Witness        string          `json:"witness" prompt:"witness,string" prompt_description:"The person from {seriesName} who witnessed the document signing." prompt_aliases:"witnessName,witnessedBy"`
+	IsParsed       bool            `json:"isParsed" prompt:"isParsed,bool"`
+	Count          int             `json:"count" prompt:"count,integer"`
+	Status         string          `json:"status" prompt:"status,string" prompt_enum:"active,inactive,pending"`
+	StatusCode     int             `json:"statusCode" prompt:"statusCode,integer,httpStatus" prompt_enum:"200,400,500" prompt_description:"HTTP status code for the document"`
+	Percentage     float64         `json:"percentage" prompt:"percentage,number"`
+	Amount         decimal.Decimal `json:"amount" prompt:"amount,number"`
+	Metadata       Metadata        `json:"metadata" prompt:"metadata,object"`
+	Tags           []string        `json:"tags" prompt:"tags,string"`
+	Events         []Event         `json:"events" prompt:"events,object"`
+	SpecialEvent   *Event          `json:"specialEvent" prompt:"specialEvent,object"`
+	OptionalEvents []*Event        `json:"optionalEvents" prompt:"optionalEvents,object"`
+	TagSets        [][]string      `json:"tagSets" prompt:"tagSets,string"`
+	Embedded
 }
 
 type InvalidType struct {
 	Field string `json:"invalidField" prompt:"invalidField,"`
 }
+
+type TypeMismatch struct {
+	Field string `json:"mismatchedField" prompt:"mismatchedField,integer"`
+}
+
 type WrongNumberOfParams struct {
 	Field string `json:"wrongNumberOfParams" prompt:"wrongNumberOfParams"`
 }
 
-var _ = Describe("Ai Utils", func() {
+type UnsupportedType struct {
+	Field complex64 `json:"unsupportedField" prompt:"unsupportedField,integer"`
+}
+
+var _ = Describe("Transform", func() {
 	Describe("MarshalResponseSchema", func() {
 		var schema *genai.Schema
 
@@ -52,14 +75,38 @@ var _ = Describe("Ai Utils", func() {
 		})
 
 		Context("success", func() {
+			It("should succeed with a pointer to a struct", func() {
+				schema, err := prompterizer.MarshalResponseSchema(&TestPrompt{}, map[string]string{"seriesName": "Business 101"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(schema).NotTo(BeNil())
+			})
+
+			It("should ignore unexported fields", func() {
+				_ = TestPrompt{}.unexported // to avoid unused variable lint error
+				Expect(schema.Properties).ToNot(HaveKey("unexported"))
+			})
+
+			It("should ignore fields without a prompt tag", func() {
+				Expect(schema.Properties).ToNot(HaveKey("ignored"))
+			})
+
 			It("should marshal a time.Time property", func() {
 				Expect(schema).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Properties": HaveKey("documentDate"),
-					"Required":   Equal([]string{"documentDate"}),
+					"Required":   ContainElement("documentDate"),
 				})))
 
 				Expect(schema.Properties["documentDate"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(genai.TypeString),
+				})))
+			})
+
+			It("should marshal a property with explicit format if provided in prompt tag", func() {
+				Expect(schema.Required).To(ContainElement("creationDate"))
+				Expect(schema.Properties).To(HaveKey("creationDate"))
+				Expect(schema.Properties["creationDate"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(genai.TypeString),
+					"Format": Equal("date-time"),
 				})))
 			})
 
@@ -110,9 +157,45 @@ var _ = Describe("Ai Utils", func() {
 				})))
 			})
 
+			It("should marshal an integer property", func() {
+				Expect(schema.Properties).To(HaveKey("count"))
+				Expect(schema.Properties["count"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type": Equal(genai.TypeInteger),
+				})))
+			})
+
+			It("should marshal a property with enum values and enum format if prompt_enum is set", func() {
+				Expect(schema.Properties).To(HaveKey("status"))
+
+				Expect(schema.Properties["status"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(genai.TypeString),
+					"Format": Equal("enum"),
+					"Enum":   ConsistOf("active", "inactive", "pending"),
+				})))
+			})
+
+			It("should marshal a property with the explicit format even if prompt_enum is set", func() {
+				Expect(schema.Properties).To(HaveKey("statusCode"))
+
+				Expect(schema.Properties["statusCode"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(genai.TypeInteger),
+					"Format": Equal("httpStatus"),
+					"Enum":   ConsistOf("200", "400", "500"),
+				})))
+			})
+
+			It("should marshal a property with a float format for number type", func() {
+				Expect(schema.Properties).To(HaveKey("percentage"))
+
+				Expect(schema.Properties["percentage"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(genai.TypeNumber),
+					"Format": Equal("float"),
+				})))
+			})
+
 			It("should marshal a decimal.Decimal property", func() {
-				Expect(schema.Properties).To(HaveKey("totalAmount"))
-				Expect(schema.Properties["totalAmount"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+				Expect(schema.Properties).To(HaveKey("amount"))
+				Expect(schema.Properties["amount"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(genai.TypeNumber),
 				})))
 			})
@@ -126,16 +209,6 @@ var _ = Describe("Ai Utils", func() {
 							"Type": Equal(genai.TypeString),
 						})),
 					}),
-				})))
-			})
-
-			It("should marshal an array of strings", func() {
-				Expect(schema.Properties).To(HaveKey("tags"))
-				Expect(schema.Properties["tags"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type": Equal(genai.TypeArray),
-					"Items": PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type": Equal(genai.TypeString),
-					})),
 				})))
 			})
 
@@ -154,19 +227,74 @@ var _ = Describe("Ai Utils", func() {
 				})))
 			})
 
-			It("should ignore fields without a prompt tag", func() {
-				Expect(schema.Properties).ToNot(HaveKey("ignored"))
+			It("should marshal a pointer field as nullable", func() {
+				Expect(schema.Properties).To(HaveKey("specialEvent"))
+
+				Expect(schema.Properties["specialEvent"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(genai.TypeObject),
+					"Nullable": PointTo(BeTrue()),
+				})))
 			})
 
-			It("should render variables into the description", func() {
-				Expect(schema.Properties).To(HaveKey("title"))
-				Expect(schema.Properties["title"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Description": Equal("The title of the document under the series Business 101"),
+			It("should marshal a slice of pointers", func() {
+				Expect(schema.Properties).To(HaveKey("optionalEvents"))
+				Expect(schema.Properties["optionalEvents"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type": Equal(genai.TypeArray),
+					"Items": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(genai.TypeObject),
+						"Nullable": PointTo(BeTrue()),
+					})),
+				})))
+			})
+
+			It("should marshal a nested array of strings", func() {
+				Expect(schema.Properties).To(HaveKey("tagSets"))
+				Expect(schema.Properties["tagSets"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type": Equal(genai.TypeArray),
+					"Items": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(genai.TypeArray),
+						"Items": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(genai.TypeString),
+						})),
+					})),
+				})))
+			})
+
+			It("should marshal an embedded struct's fields", func() {
+				Expect(schema.Required).To(ContainElement("embeddedField"))
+				Expect(schema.Properties).To(HaveKey("embeddedField"))
+				Expect(schema.Properties["embeddedField"]).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type": Equal(genai.TypeString),
 				})))
 			})
 		})
 
 		Context("errors", func() {
+			It("should return an error if the value is nil", func() {
+				_, err := prompterizer.MarshalResponseSchema(nil, map[string]string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("input value for schema generation cannot be nil"))
+			})
+
+			It("should return an error if the value is not a struct", func() {
+				_, err := prompterizer.MarshalResponseSchema("not a struct", map[string]string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("input value for schema generation must be a struct, got string"))
+			})
+
+			It("should return an error if the value is a pointer to a non-struct", func() {
+				invalidInput := "not a struct"
+				_, err := prompterizer.MarshalResponseSchema(&invalidInput, map[string]string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("input value for schema generation must be a struct, got string"))
+			})
+
+			It("should return an error if there is an attempt to marshal without all the required template variables", func() {
+				_, err := prompterizer.MarshalResponseSchema(TestPrompt{}, map[string]string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("missing variables in description: seriesName"))
+			})
+
 			It("should return an error when there are an incorrect number of params", func() {
 				_, err := prompterizer.MarshalResponseSchema(WrongNumberOfParams{}, map[string]string{})
 				Expect(err).To(HaveOccurred())
@@ -176,13 +304,19 @@ var _ = Describe("Ai Utils", func() {
 			It("should return an error for an invalid field type", func() {
 				_, err := prompterizer.MarshalResponseSchema(InvalidType{}, map[string]string{})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unsupported property type"))
+				Expect(err.Error()).To(ContainSubstring("unsupported field type"))
 			})
 
-			It("should return an error if there is an attempt to marshal without all the required template variables", func() {
-				_, err := prompterizer.MarshalResponseSchema(TestPrompt{}, map[string]string{})
+			It("should return an error for a type mismatch", func() {
+				_, err := prompterizer.MarshalResponseSchema(TypeMismatch{}, map[string]string{})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("missing variables in description: seriesName"))
+				Expect(err.Error()).To(ContainSubstring("type mismatch for field 'mismatchedField': Go type implies STRING, but prompt tag specifies INTEGER"))
+			})
+
+			It("should return an error for an unsupported type", func() {
+				_, err := prompterizer.MarshalResponseSchema(UnsupportedType{}, map[string]string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("error marshaling property unsupportedField (Go field Field, type complex64): unsupported type kind for schema generation: complex64 (Go type: complex64)"))
 			})
 		})
 	})


### PR DESCRIPTION
- Fix handling of pointer types
- Allow prompt type to override reflected type for objects, to allow deserialization of types like `time.Time` and `decimal.Decimal`
- Add support for explicit format strings
- Add support for enum values
- BREAKING CHANGE: Enforce reflected type and specified type match
- BREAKING CHANGE: Remove prompt type `array`, infer that from reflected field. Prompt type is expected to represent the element type

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZHRrdnRiaWltbTRlcnRlM29rdnQxc3czbHp2MzVqN2RkZTVueWI1ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/D2lBfo5yPk9ZKAO7VZ/giphy.gif"/>