### PR TITLE
Fixes the schema generation for slices

### DIFF
--- a/transform_test.go
+++ b/transform_test.go
@@ -103,11 +103,21 @@ var _ = Describe("Transform", func() {
 				Expect(schema.Type).To(Equal(genai.TypeObject))
 			})
 
-			It("should succeed with a slice", func() {
+			It("should succeed with a slice of objects", func() {
 				schema, err := prompterizer.MarshalResponseSchema([]TestPrompt{}, map[string]string{"seriesName": "Business 101", "dynamicEnumValues": dynamicEnumValues})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(schema).NotTo(BeNil())
 				Expect(schema.Type).To(Equal(genai.TypeArray))
+				Expect(schema.Items.Type).To(Equal(genai.TypeObject))
+			})
+
+			It("should succeed with a slice of slices", func() {
+				schema, err := prompterizer.MarshalResponseSchema([][]TestPrompt{}, map[string]string{"seriesName": "Business 101", "dynamicEnumValues": dynamicEnumValues})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(schema).NotTo(BeNil())
+				Expect(schema.Type).To(Equal(genai.TypeArray))
+				Expect(schema.Items.Type).To(Equal(genai.TypeArray))
+				Expect(schema.Items.Items.Type).To(Equal(genai.TypeObject))
 			})
 
 			It("should ignore unexported fields", func() {


### PR DESCRIPTION
Currently, it uses the `promptType` provided for the next recursive generation when marshalling for a slice. This results in an array of arrays being the `Schema` generated, where in most cases, we probably what an array of objects.
This adjusts to look at the type of the slice and then either generate object or array as the next layer as appropriate (i.e., it's either a slice of objects or slice of arrays).

Validates with unit tests (also promptfoundry works the fix)